### PR TITLE
unattended install for winpcap, removed package icon

### DIFF
--- a/WinPcap/WinPcap.nuspec
+++ b/WinPcap/WinPcap.nuspec
@@ -2,18 +2,23 @@
 <package >
   <metadata>
     <id>WinPcap</id>
-    <version>4.1.3</version>
+    <version>4.1.3.20130806</version>
     <authors>NetGroup, CACE Technologies</authors>
     <owners>zippy1981 ferventcoder</owners>
     <licenseUrl>http://www.winpcap.org/misc/copyright.htm</licenseUrl>
     <projectUrl>http://www.winpcap.org/</projectUrl>
-    <iconUrl>http://www.winpcap.org/favicon.ico</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>WinPcap is the industry-standard tool for link-layer network access in Windows environments: it allows applications to capture and transmit network packets bypassing the protocol stack, and has additional useful features, including kernel-level packet filtering, a network statistics engine and support for remote packet capture.
-Note: This package does not install silently. This feature was removed from the original installer due to misuse.</description>
+Note: This package uses an Autohotkey script for unattended installation.</description>
     <releaseNotes>Added an uninstaller.</releaseNotes>
-    <copyright>Copyright (c) 1999 - 2005 NetGroup, Politecnico di Torino (Italy).
-Copyright (c) 2005 - 2010 CACE Technologies, Davis (California).</copyright>
+    <copyright>Copyright (c) 1999–2005 NetGroup, Politecnico di Torino (Italy).
+Copyright (c) 2005–2010 CACE Technologies, Davis (California).</copyright>
     <tags>chocolatey driver packetcapture network</tags>
+    <dependencies>
+        <dependency id="autohotkey_l.portable" />
+    </dependencies>
   </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
 </package>

--- a/WinPcap/tools/chocolateyInstall.ps1
+++ b/WinPcap/tools/chocolateyInstall.ps1
@@ -1,1 +1,20 @@
-﻿Install-ChocolateyPackage 'winpcap' 'exe' '' 'https://www.winpcap.org/install/bin/WinPcap_4_1_3.exe'
+﻿try {
+    $packageName = 'winpcap'
+    $url = 'https://www.winpcap.org/install/bin/WinPcap_4_1_3.exe'
+    $filePath = "$env:TEMP\chocolatey\winpcap"
+    $fileFullPath = "$filePath\winpcapInstall.exe"
+
+    if (!(Test-Path $filePath)) {
+        New-Item -ItemType directory $filePath -Force
+    }
+
+    Get-ChocolateyWebFile $packageName $fileFullPath $url
+
+    $ahkScript = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)\winpcapInstall.ahk"
+
+    Start-ChocolateyProcessAsAdmin $ahkScript 'AutoHotkey'
+
+}   catch {
+    Write-ChocolateyFailure $packageName $($_.Exception.Message)
+    throw
+}

--- a/WinPcap/tools/winpcapInstall.ahk
+++ b/WinPcap/tools/winpcapInstall.ahk
@@ -1,0 +1,80 @@
+﻿#NoEnv  ; Recommended for performance and compatibility with future AutoHotkey releases.
+; #Warn  ; Enable warnings to assist with detecting common errors.
+SendMode Input  ; Recommended for new scripts due to its superior speed and reliability.
+SetWorkingDir %A_ScriptDir%  ; Ensures a consistent starting directory.
+SetTitleMatchMode, RegEx
+
+; uninstalling part
+
+ProgramFilesX86 := A_ProgramFiles . (A_PtrSize=8 ? " (x86)" : "")
+
+winpcapUninstaller = %A_ProgramFiles%\WinPcap\Uninstall.exe
+winpcapUninstallerx86 = %ProgramFilesX86%\WinPcap\Uninstall.exe
+
+IfExist, %winpcapUninstaller%
+{
+	Run, %winpcapUninstaller%
+	installed = 1
+}
+IfExist, %winpcapUninstallerx86%
+{
+	Run, %winpcapUninstallerx86%
+	installed = 1
+}
+if (installed = 1)
+{
+	WinWait, WinPcap [\d\.]+ Uninstall,, 30
+	IfWinExist
+	{
+		BlockInput, On
+		Sleep, 250
+		WinActivate
+		Send, {Enter}
+		BlockInput, Off
+	}
+
+	WinWait, WinPcap [\d\.]+ Uninstall, has been uninstalled, 30
+		IfWinExist
+		{
+			BlockInput, On
+			Sleep, 250
+			WinActivate
+			Send, {Enter}
+			BlockInput, Off
+		}
+}
+
+; installing part
+
+winpcapInstaller = %A_Temp%\chocolatey\winpcap\winpcapInstall.exe
+Run, %winpcapInstaller%
+
+WinWait, WinPcap [\d\.]+ Setup,, 30
+
+Loop, 3
+{
+	gosub, setupForward
+}
+
+WinWait, WinPcap [\d\.]+ Setup, has been installed, 30
+	IfWinExist
+	{
+		BlockInput, On
+		Sleep, 250
+		WinActivate
+		Send, {Enter}
+		BlockInput, Off
+	}
+
+ExitApp
+
+setupForward:
+	IfWinExist
+	{
+		BlockInput, On
+		Sleep, 250
+		WinActivate
+		Send, {Enter}
+		BlockInput, Off
+	}
+return


### PR DESCRIPTION
The authors of WinPcap removed the silent install feature. But for chocolatey packages it’s essential to have silent/unattended installing packages. Therefore I created an AutoHotkey script which handles this. I hope you like it.

In addition I removed the package icon. The icon was only 16 × 16 px and thus doesn’t meet the package icon guidelines: https://github.com/chocolatey/chocolatey/wiki/CreatePackages#package-icon-guidelines

I tested the updated package and it works fine.
