### PR TITLE
Bump inkscape to v0.48.5

### DIFF
--- a/Inkscape/InkScape.nuspec
+++ b/Inkscape/InkScape.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>InkScape</id>
-        <version>0.48.4.0</version>
+        <version>0.48.5.0</version>
         <title>InkScape</title>
         <authors>Inkscape developers</authors>
         <owners>zippy1981 MarkJohnson/</owners>

--- a/Inkscape/tools/chocolateyInstall.ps1
+++ b/Inkscape/tools/chocolateyInstall.ps1
@@ -2,16 +2,16 @@
   if (Test-Path HKLM:SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\Inkscape) {
     $installedVersion = [Version] (Get-ItemProperty HKLM:SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\Inkscape DisplayVersion).DisplayVersion
   }
-  if ($installedVersion -eq [Version] '0.48.4.0') {
+  if ($installedVersion -eq [Version] '0.48.5.0') {
     Write-ChocolateySuccess 'inkscape' 'Inkscape is already installed. Updating the chococolatey database.'
   }
-  elseif ($installedVersion -gt [Version] '0.48.4.0') {
+  elseif ($installedVersion -gt [Version] '0.48.5.0') {
     Write-ChocolateyFailure 'inkscape' "A newer version of inkscape [$($installedVersion)] is already installed. Updating the chococolatey database."
   }
   else {
-    Install-ChocolateyPackage 'inkscape' 'exe' '/S' 'https://downloads.sourceforge.net/project/inkscape/inkscape/0.48.4/inkscape-0.48.4-1-win32.exe?use_mirror=switch'
+    Install-ChocolateyPackage 'inkscape' 'exe' '/S' 'http://sourceforge.net/projects/inkscape/files/inkscape/0.48.5/Inkscape-0.48.5-1-win32.exe/download'
   }
 } catch {
   Write-ChocolateyFailure 'inkscape' "$($_.Exception.Message)"
-  throw 
+  throw
 }


### PR DESCRIPTION
There’s a new version of Inkscape. Can you merge this and push the updated package to the gallery? That would be great.
